### PR TITLE
Add schema-driven lead form and update CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ wittwizz/
 │   │   ├── Hero.tsx      # Animated hero with typewriter
 │   │   ├── Features.tsx  # Feature showcase grid
 │   │   ├── Services.tsx  # Service offerings
-│   │   └── Packages.tsx  # Pricing packages
+│   │   ├── Packages.tsx  # Pricing packages
+│   │   └── LeadForm.tsx  # Conversion-focused lead capture
 │   ├── ui/               # Core UI components
 │   │   ├── AnimatedBackground.tsx    # Floating particles & shapes
 │   │   ├── GradientBorderCard.tsx    # Interactive cards
@@ -53,6 +54,15 @@ npm run build        # Build for production
 npm run preview      # Preview production build
 ```
 
+### Environment Variables
+
+The new lead form expects an automation endpoint and (optionally) a scheduling link:
+
+| Variable | Purpose |
+| --- | --- |
+| `VITE_LEAD_FORM_ENDPOINT` | HTTPS endpoint that receives POST requests with JSON payloads for each submission (e.g., Zapier, Make, Airtable webhook, custom backend). |
+| `VITE_FOUNDER_CALL_URL` | Optional Calendly/Meet link for founders who prefer booking a call. If omitted, the site falls back to email. |
+
 ## 🎨 Design System
 
 ### Color Palette
@@ -85,7 +95,8 @@ npm run preview      # Preview production build
 2. **Features** - 8 feature cards with gradient borders
 3. **Services** - 3 service offerings + process steps
 4. **Packages** - 3 pricing tiers with popular highlighting
-5. **Final CTA** - Seamless conclusion with trust indicators
+5. **Lead Form** - Schema-driven launch sprint intake with automation-ready submit handler
+6. **Final CTA** - Seamless conclusion with trust indicators
 
 ## 🔮 Future Enhancements
 

--- a/src/components/AppRouter.tsx
+++ b/src/components/AppRouter.tsx
@@ -4,6 +4,7 @@ import Hero from '../sections/Hero';
 import Features from '../sections/Features';
 import Services from '../sections/Services';
 import Packages from '../sections/Packages';
+import LeadForm from '../sections/LeadForm';
 import FinalCTA from '../ui/FinalCTA';
 import SEOHead from './SEOHead';
 
@@ -19,10 +20,12 @@ const AppRouter: React.FC = () => {
       if (redirectPath.includes('#')) {
         const hash = redirectPath.split('#')[1];
         const sectionMap: { [key: string]: number } = {
-          'features': 1,
-          'services': 2,
-          'packages': 3,
-          'contact': 4
+          features: 1,
+          services: 2,
+          packages: 3,
+          lead_form: 4,
+          'lead-form': 4,
+          contact: 5
         };
         if (sectionMap[hash] !== undefined) {
           setTimeout(() => scrollToSection(sectionMap[hash]), 100);
@@ -43,7 +46,8 @@ const AppRouter: React.FC = () => {
         { id: 1, element: document.querySelector('[data-section="features"]') },
         { id: 2, element: document.querySelector('[data-section="services"]') },
         { id: 3, element: document.querySelector('[data-section="packages"]') },
-        { id: 4, element: document.querySelector('[data-section="final-cta"]') }
+        { id: 4, element: document.querySelector('[data-section="lead-form"]') },
+        { id: 5, element: document.querySelector('[data-section="final-cta"]') }
       ];
 
       let activeSection = 0;
@@ -70,13 +74,7 @@ const AppRouter: React.FC = () => {
 
   // Function to scroll to a specific section
   const scrollToSection = (sectionIndex: number) => {
-    const sections = [
-      'hero',
-      'features', 
-      'services',
-      'packages',
-      'final-cta'
-    ];
+    const sections = ['hero', 'features', 'services', 'packages', 'lead-form', 'final-cta'];
     
     const targetSection = document.querySelector(`[data-section="${sections[sectionIndex]}"]`);
     if (targetSection) {
@@ -108,6 +106,11 @@ const AppRouter: React.FC = () => {
         canonical: "https://wittwizz.github.io/Wittwizz/#packages"
       },
       {
+        title: "Plan Your Sprint - Wittwiz Digital",
+        description: "Tell us about your goals and budget to receive a tailored Wittwiz launch sprint plan.",
+        canonical: "https://wittwizz.github.io/Wittwizz/#lead_form"
+      },
+      {
         title: "Contact Us - Wittwiz Digital",
         description: "Get started with Wittwiz Digital. Schedule a call or start your project today.",
         canonical: "https://wittwizz.github.io/Wittwizz/#contact"
@@ -137,6 +140,9 @@ const AppRouter: React.FC = () => {
         </div>
         <div data-section="packages">
           <Packages />
+        </div>
+        <div data-section="lead-form">
+          <LeadForm />
         </div>
         <div data-section="final-cta">
           <FinalCTA />

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { ArrowRight, Sparkles, Zap, Target } from 'lucide-react';
 import { TypewriterEffect } from '@/ui';
+import { openLeadForm } from '@/utils/leadForm';
+import { openFounderCall } from '@/utils/contact';
 
 export default function Hero() {
   return (
@@ -65,52 +67,22 @@ export default function Hero() {
 
         {/* CTA Buttons */}
         <div className="flex flex-col sm:flex-row items-center justify-center gap-6 mb-16">
-          <button 
-            onClick={() => {
-              const packagesSection = document.querySelector('[data-section="packages"]');
-              if (packagesSection) {
-                packagesSection.scrollIntoView({ behavior: 'smooth' });
-              }
-            }}
+          <button
+            onClick={() =>
+              openLeadForm({
+                goal: 'Plan my 30-day launch sprint',
+                context: 'Ready for the 30-day launch plan'
+              })
+            }
             className="bg-gradient-to-r from-accent-primary to-accent-secondary text-bg-primary font-semibold px-8 py-4 rounded-lg shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300 border-0 flex items-center gap-3 group cursor-pointer"
           >
             <Target className="w-5 h-5" />
             See the 30-day launch plan
             <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform duration-300" />
           </button>
-          
+
           <button
-            onClick={() => {
-              const subject = encodeURIComponent("🚀 Book My Traction Validation Call - Wittwiz Digital");
-              const body = encodeURIComponent(`Hi Wittwiz Team! 👋
-
-I'm ready to validate a 30-day launch with Wittwiz. Here's what I'm building:
-
-🎯 **Startup Snapshot:**
-[Tell us about your product, audience, and current traction]
-
-📈 **Targets for the Next 30 Days:**
-- Qualified leads or sign-ups goal
-- Revenue or activation milestone
-- Launch date or campaign deadline
-
-🧰 **Support I Need:**
-- Brand and story alignment
-- Conversion-first website or funnel
-- Paid demand engine
-
-💰 **Current Stage:** [Idea, MVP, Post-MVP, etc.]
-📱 **Best Contact:** [Your preferred contact method]
-
-Excited to co-create the launch plan with Wittwiz!
-
-Best,
-[Your Name]
-[Your Contact Number]`);
-
-              const mailtoLink = `mailto:wittwizdigitals@gmail.com?subject=${subject}&body=${body}`;
-              window.open(mailtoLink, '_blank');
-            }}
+            onClick={openFounderCall}
             className="bg-bg-tertiary/80 backdrop-blur-md text-accent-primary border-2 border-accent-primary font-semibold px-8 py-4 rounded-lg hover:bg-accent-primary hover:text-bg-primary transition-all duration-300 flex items-center gap-3 group cursor-pointer"
           >
             <Zap className="w-5 h-5" />

--- a/src/sections/LeadForm.tsx
+++ b/src/sections/LeadForm.tsx
@@ -1,0 +1,365 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import contentMatrix from '../../content/website/content-matrix.json';
+import { LeadFormField, LeadFormPrefill, subscribeToLeadFormPrefill } from '@/utils/leadForm';
+import { openFounderCall } from '@/utils/contact';
+
+const leadFormContent = contentMatrix.lead_form;
+
+const stageOptions = ['Idea', 'MVP', 'Post-revenue', 'Scaling', 'Other'];
+const timelineOptions = ['Immediately', '2-4 weeks', '1-2 months', 'Flexible'];
+
+interface FieldConfig {
+  label: string;
+  placeholder?: string;
+  type: 'text' | 'email' | 'textarea' | 'select' | 'radio';
+  options?: string[];
+  required?: boolean;
+  helper?: string;
+}
+
+const fieldConfig: Record<LeadFormField, FieldConfig> = {
+  name: {
+    label: 'Your name',
+    placeholder: 'Aarav Patel',
+    type: 'text',
+    required: true
+  },
+  email: {
+    label: 'Work email',
+    placeholder: 'founder@startup.com',
+    type: 'email',
+    required: true
+  },
+  company: {
+    label: 'Startup / company',
+    placeholder: 'Wittwiz Digital',
+    type: 'text',
+    required: true
+  },
+  role: {
+    label: 'Role',
+    placeholder: 'Founder, Growth lead…',
+    type: 'text'
+  },
+  stage: {
+    label: 'Current stage',
+    type: 'select',
+    options: stageOptions,
+    required: true
+  },
+  goal: {
+    label: 'What should we ship in 30 days?',
+    placeholder: 'Conversion site, paid experiments, growth ops…',
+    type: 'textarea',
+    required: true
+  },
+  timeline: {
+    label: 'Ideal timeline',
+    type: 'select',
+    options: timelineOptions,
+    required: true
+  },
+  budget_band: {
+    label: 'Budget band',
+    type: 'radio',
+    options: leadFormContent.budget_bands,
+    required: true,
+    helper: 'Pick the closest band. We use this to plan sprint velocity.'
+  },
+  referral: {
+    label: 'How did you hear about us?',
+    placeholder: 'Referral, LinkedIn, community, etc.',
+    type: 'text'
+  }
+};
+
+const createInitialState = () =>
+  leadFormContent.fields.reduce<Record<LeadFormField, string>>((acc, field) => {
+    acc[field as LeadFormField] = '';
+    return acc;
+  }, {} as Record<LeadFormField, string>);
+
+const orderedFields = leadFormContent.fields as LeadFormField[];
+
+const LeadForm: React.FC = () => {
+  const [formData, setFormData] = useState<Record<LeadFormField, string>>(() => createInitialState());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [contextNote, setContextNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToLeadFormPrefill((payload: LeadFormPrefill) => {
+      setFormData((prev) => {
+        const next = { ...prev };
+        (Object.keys(payload) as Array<keyof LeadFormPrefill>).forEach((key) => {
+          if (!payload[key]) {
+            return;
+          }
+
+          if (key in next) {
+            next[key as LeadFormField] = payload[key] as string;
+          }
+        });
+        return next;
+      });
+
+      if (payload.context) {
+        setContextNote(payload.context);
+      } else if (payload.goal) {
+        setContextNote(`Goal updated: ${payload.goal}`);
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const handleChange = (field: LeadFormField, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (status !== 'idle') {
+      setStatus('idle');
+      setStatusMessage('');
+    }
+  };
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+
+    const missingField = orderedFields.find((fieldKey) => {
+      const config = fieldConfig[fieldKey];
+      return config?.required && !formData[fieldKey];
+    });
+
+    if (missingField) {
+      setStatus('error');
+      setStatusMessage('Please complete all required fields before submitting.');
+      return;
+    }
+
+    const endpoint = import.meta.env.VITE_LEAD_FORM_ENDPOINT as string | undefined;
+
+    if (!endpoint) {
+      setStatus('error');
+      setStatusMessage('Lead capture endpoint is missing. Set VITE_LEAD_FORM_ENDPOINT in your environment.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setStatus('idle');
+    setStatusMessage('');
+
+    try {
+      const payload = {
+        ...formData,
+        submittedAt: new Date().toISOString(),
+        source: 'wittwizz-site',
+        pageUrl: typeof window !== 'undefined' ? window.location.href : '',
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : ''
+      };
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      setStatus('success');
+      setStatusMessage("Thanks! We'll reply within a business day.");
+      setFormData(createInitialState());
+      setContextNote(null);
+    } catch (error) {
+      console.error('Lead form submission failed', error);
+      setStatus('error');
+      setStatusMessage('Something went wrong. Please retry or email hello@wittwizz.com.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section id="lead_form" className="relative py-24">
+      <div className="container mx-auto px-4">
+        <div className="max-w-5xl mx-auto bg-bg-tertiary/70 backdrop-blur-xl border border-accent-primary/20 rounded-3xl p-10 shadow-2xl">
+          <motion.div
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+            className="mb-10 text-center"
+          >
+            <span className="inline-flex items-center px-4 py-2 rounded-full bg-accent-primary/10 text-accent-primary text-sm font-semibold mb-4">
+              Plan my launch sprint
+            </span>
+            <h2 className="text-4xl md:text-5xl font-black text-text-primary mb-4">
+              {leadFormContent.intro}
+            </h2>
+            <p className="text-text-secondary max-w-2xl mx-auto">
+              Share a few details so the team can scope the right sprint, budget, and first-week deliverables.
+            </p>
+
+            {contextNote && (
+              <div className="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-full border border-accent-secondary/40 bg-accent-secondary/10 text-accent-secondary text-sm font-medium">
+                <span>✨</span>
+                <span>{contextNote}</span>
+              </div>
+            )}
+          </motion.div>
+
+          <form onSubmit={handleSubmit} className="space-y-10">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {orderedFields.map((fieldKey) => {
+                const config = fieldConfig[fieldKey];
+
+                if (!config) {
+                  return null;
+                }
+
+                const value = formData[fieldKey] ?? '';
+
+                if (config.type === 'textarea') {
+                  return (
+                    <label key={fieldKey} className="md:col-span-2 block">
+                      <span className="block text-sm font-semibold text-text-primary mb-2">
+                        {config.label}
+                        {config.required && <span className="text-accent-secondary"> *</span>}
+                      </span>
+                      <textarea
+                        value={value}
+                        onChange={(event) => handleChange(fieldKey, event.target.value)}
+                        required={config.required}
+                        placeholder={config.placeholder}
+                        className="w-full h-32 md:h-40 rounded-2xl border border-accent-primary/20 bg-bg-secondary/70 backdrop-blur-sm px-4 py-3 text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary/60 transition"
+                      />
+                    </label>
+                  );
+                }
+
+                if (config.type === 'select') {
+                  return (
+                    <label key={fieldKey} className="block">
+                      <span className="block text-sm font-semibold text-text-primary mb-2">
+                        {config.label}
+                        {config.required && <span className="text-accent-secondary"> *</span>}
+                      </span>
+                      <div className="relative">
+                        <select
+                          value={value}
+                          onChange={(event) => handleChange(fieldKey, event.target.value)}
+                          required={config.required}
+                          className="w-full appearance-none rounded-2xl border border-accent-primary/20 bg-bg-secondary/70 backdrop-blur-sm px-4 py-3 text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary/60 transition"
+                        >
+                          <option value="" disabled>
+                            {config.placeholder ?? 'Select one'}
+                          </option>
+                          {config.options?.map((option) => (
+                            <option key={option} value={option}>
+                              {option}
+                            </option>
+                          ))}
+                        </select>
+                        <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-text-secondary">▾</span>
+                      </div>
+                    </label>
+                  );
+                }
+
+                if (config.type === 'radio') {
+                  return (
+                    <fieldset key={fieldKey} className="md:col-span-2">
+                      <legend className="block text-sm font-semibold text-text-primary mb-2">
+                        {config.label}
+                        {config.required && <span className="text-accent-secondary"> *</span>}
+                      </legend>
+                      {config.helper && <p className="text-xs text-text-secondary mb-4">{config.helper}</p>}
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        {config.options?.map((option) => {
+                          const isActive = value === option;
+                          return (
+                            <button
+                              key={option}
+                              type="button"
+                              onClick={() => handleChange(fieldKey, option)}
+                              className={`rounded-2xl border px-4 py-3 text-left transition-all duration-200 ${
+                                isActive
+                                  ? 'border-accent-primary bg-accent-primary/10 text-accent-primary shadow-lg'
+                                  : 'border-accent-primary/20 bg-bg-secondary/70 text-text-secondary hover:border-accent-primary/40 hover:text-text-primary'
+                              }`}
+                            >
+                              {option}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </fieldset>
+                  );
+                }
+
+                return (
+                  <label key={fieldKey} className="block">
+                    <span className="block text-sm font-semibold text-text-primary mb-2">
+                      {config.label}
+                      {config.required && <span className="text-accent-secondary"> *</span>}
+                    </span>
+                    <input
+                      type={config.type}
+                      value={value}
+                      onChange={(event) => handleChange(fieldKey, event.target.value)}
+                      required={config.required}
+                      placeholder={config.placeholder}
+                      className="w-full rounded-2xl border border-accent-primary/20 bg-bg-secondary/70 backdrop-blur-sm px-4 py-3 text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-primary/60 transition"
+                    />
+                  </label>
+                );
+              })}
+            </div>
+
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+              <div className="text-sm text-text-secondary md:max-w-md">
+                {leadFormContent.privacy_note}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="inline-flex items-center justify-center gap-3 px-6 py-3 rounded-xl bg-gradient-to-r from-accent-primary to-accent-secondary text-bg-primary font-semibold shadow-lg hover:shadow-xl transition-all duration-300 disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? 'Sending…' : leadFormContent.submit_text}
+                </button>
+                <button
+                  type="button"
+                  onClick={openFounderCall}
+                  className="inline-flex items-center justify-center gap-3 px-6 py-3 rounded-xl border-2 border-accent-primary text-accent-primary font-semibold hover:bg-accent-primary hover:text-bg-primary transition-all duration-300"
+                >
+                  Prefer a call?
+                </button>
+              </div>
+            </div>
+
+            {status !== 'idle' && (
+              <div
+                role="alert"
+                className={`rounded-2xl border px-4 py-3 text-sm font-medium ${
+                  status === 'success'
+                    ? 'border-emerald-400 bg-emerald-500/10 text-emerald-200'
+                    : 'border-red-400 bg-red-500/10 text-red-200'
+                }`}
+              >
+                {statusMessage}
+              </div>
+            )}
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default LeadForm;

--- a/src/sections/Packages.tsx
+++ b/src/sections/Packages.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Check, Zap, Rocket, TrendingUp, Star, ArrowRight, Target, Shield } from 'lucide-react';
 import { StaggeredContainer, GradientBorderCard } from '@/ui';
+import { openLeadForm } from '@/utils/leadForm';
 
 const packages = [
   {
@@ -62,29 +63,6 @@ const packages = [
 ];
 
 export default function Packages() {
-  const handleGetCustomQuote = () => {
-    const message = encodeURIComponent(`Hi Wittwiz Team! 👋
-
-I'm interested in getting a custom quote for my startup project! Here's what I'm looking for:
-
-🎯 **My Startup:**
-[Brief description of your amazing idea]
-
-💡 **What I Need:**
-[Specific services you require - e.g., custom website, advanced branding, growth strategy, etc.]
-
-💰 **Budget Range:** [Your budget range]
-⏰ **Timeline:** [When you want to launch]
-📱 **Best Contact:** [Your preferred contact method]
-
-I'm excited to discuss how Wittwiz can help me create something incredible! 
-
-Looking forward to hearing from you! 🚀✨`);
-
-    const whatsappLink = `https://wa.me/918800608399?text=${message}`;
-    window.open(whatsappLink, '_blank');
-  };
-
   return (
     <section className="py-20 relative overflow-hidden min-h-screen flex items-center">
       <div className="container mx-auto px-4 relative z-10">
@@ -174,39 +152,13 @@ Looking forward to hearing from you! 🚀✨`);
                   </ul>
                   
                   {/* CTA Button */}
-                  <button 
-                    onClick={() => {
-                      const subject = encodeURIComponent(`🚀 Interested in ${pkg.name} Package - Wittwiz Digital`);
-                      const body = encodeURIComponent(`Hi Wittwiz Team! 👋
-
-I'm really interested in your **${pkg.name}** package! Here's what I'm looking for:
-
-📦 **Package Details:**
-- Package: ${pkg.name}
-- Price: ${pkg.price} + 18% GST
-- Timeline: ${pkg.timeline}
-- Tagline: ${pkg.tagline}
-
-💡 **My Requirements:**
-- ${pkg.description}
-- Key features I need: ${pkg.features.slice(0, 3).join(', ')}
-
-🎯 **Next Steps:**
-I'd love to schedule a call to discuss this package in detail and get started on my project.
-
-💰 **Budget Confirmed:** Yes, within my budget range
-⏰ **Preferred Timeline:** [When you want to start]
-📱 **Best Contact:** [Your preferred contact method]
-
-I'm excited to work with Wittwiz and can't wait to get the ball rolling on my startup!
-
-Best regards,
-[Your Name]
-[Your Contact Number]`);
-
-                      const mailtoLink = `mailto:wittwizdigitals@gmail.com?subject=${subject}&body=${body}`;
-                      window.open(mailtoLink, '_blank');
-                    }}
+                  <button
+                    onClick={() =>
+                      openLeadForm({
+                        goal: `Interested in the ${pkg.name} package`,
+                        context: `${pkg.name} package selected`
+                      })
+                    }
                     className={`w-full py-3 px-6 rounded-lg font-semibold transition-all duration-300 cursor-pointer ${
                       pkg.popular
                         ? 'bg-gradient-to-r from-accent-secondary to-accent-primary text-bg-primary hover:scale-105'
@@ -226,8 +178,13 @@ Best regards,
             <p className="text-text-secondary mb-6">
               Need a custom solution? Let's discuss your specific requirements.
             </p>
-            <button 
-              onClick={handleGetCustomQuote}
+            <button
+              onClick={() =>
+                openLeadForm({
+                  goal: 'Need a custom quote',
+                  context: 'Custom solution requested'
+                })
+              }
               className="inline-flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-accent-primary to-accent-secondary text-bg-primary font-semibold rounded-lg hover:scale-105 transition-transform duration-300 cursor-pointer"
             >
               <Shield className="w-5 h-5" />

--- a/src/ui/FinalCTA.tsx
+++ b/src/ui/FinalCTA.tsx
@@ -1,54 +1,17 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import { openLeadForm } from '@/utils/leadForm';
+import { openFounderCall } from '@/utils/contact';
 
 const FinalCTA: React.FC = () => {
-  const handleStartProject = () => {
-    const subject = encodeURIComponent("🚀 Ready to Launch My Startup with Wittwiz!");
-    const body = encodeURIComponent(`Hi WittWizz Team! 👋
-
-I'm excited to start my startup journey with you! Here's what I'm looking for:
-
-🎯 **My Startup Vision:**
-[Tell us about your amazing idea]
-
-💡 **What I Need:**
-- Brand identity & positioning
-- Website development
-- Growth strategy
-- [Any other specific requirements]
-
-💰 **Budget Range:** [Your budget range]
-⏰ **Timeline:** [When you want to launch]
-
-I'm ready to transform my startup from idea to reality! Let's make something incredible together.
-
-Best regards,
-[Your Name]
-[Your Contact Number]`);
-
-    const mailtoLink = `mailto:wittwizdigitals@gmail.com?subject=${subject}&body=${body}`;
-    window.open(mailtoLink, '_blank');
-  };
+  const handleStartProject = () =>
+    openLeadForm({
+      goal: 'I want to start a Wittwiz launch sprint',
+      context: 'Start your project CTA'
+    });
 
   const handleScheduleCall = () => {
-    const subject = encodeURIComponent("📞 Schedule a Strategy Call - WittWizz");
-    const body = encodeURIComponent(`Hi WittWizz Team! 👋
-
-I'd love to schedule a call to discuss my startup strategy. Here's what I'm looking for:
-
-🎯 **My Startup:** [Brief description]
-💡 **My Goals:** [What you want to achieve]
-⏰ **Preferred Time:** [When you'd like to chat]
-📱 **Best Contact:** [Your preferred contact method]
-
-I'm excited to learn how Wittwiz can help me launch and grow my startup!
-
-Best regards,
-[Your Name]
-[Your Contact Number]`);
-
-    const mailtoLink = `mailto:wittwizdigitals@gmail.com?subject=${subject}&body=${body}`;
-    window.open(mailtoLink, '_blank');
+    openFounderCall();
   };
 
   return (

--- a/src/utils/contact.ts
+++ b/src/utils/contact.ts
@@ -1,0 +1,20 @@
+const DEFAULT_CONTACT_EMAIL = 'wittwizdigitals@gmail.com';
+
+export const openFounderCall = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const schedulingUrl = import.meta.env.VITE_FOUNDER_CALL_URL as string | undefined;
+
+  if (schedulingUrl && schedulingUrl.trim().length > 0) {
+    window.open(schedulingUrl, '_blank', 'noopener');
+    return;
+  }
+
+  const subject = encodeURIComponent('📞 Schedule a Strategy Call - Wittwiz Digital');
+  const body = encodeURIComponent(`Hi Wittwiz Team! 👋\n\nI'd love to schedule a call to discuss my startup strategy. Here's what I'm looking for:\n\n🎯 My Startup: [Brief description]\n💡 My Goals: [What you want to achieve]\n⏰ Preferred Time: [When you'd like to chat]\n📱 Best Contact: [Your preferred contact method]\n\nExcited to learn how Wittwiz can help me launch and grow!\n\nBest,\n[Your Name]\n[Your Contact Number]`);
+
+  const mailtoLink = `mailto:${DEFAULT_CONTACT_EMAIL}?subject=${subject}&body=${body}`;
+  window.open(mailtoLink, '_blank', 'noopener');
+};

--- a/src/utils/leadForm.ts
+++ b/src/utils/leadForm.ts
@@ -1,0 +1,66 @@
+export type LeadFormField =
+  | 'name'
+  | 'email'
+  | 'company'
+  | 'role'
+  | 'stage'
+  | 'goal'
+  | 'timeline'
+  | 'budget_band'
+  | 'referral';
+
+export type LeadFormPrefill = Partial<Record<LeadFormField, string>> & {
+  context?: string;
+};
+
+const LEAD_FORM_EVENT = 'lead-form:prefill';
+
+const getLeadFormElement = () => {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return (
+    document.getElementById('lead_form') ||
+    document.getElementById('lead_form_section') ||
+    document.querySelector('[data-section="lead-form"]')
+  );
+};
+
+export const openLeadForm = (prefill?: LeadFormPrefill) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (prefill && Object.keys(prefill).length > 0) {
+    window.dispatchEvent(
+      new CustomEvent<LeadFormPrefill>(LEAD_FORM_EVENT, {
+        detail: prefill
+      })
+    );
+  }
+
+  const section = getLeadFormElement();
+  if (section) {
+    section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+};
+
+export const subscribeToLeadFormPrefill = (
+  callback: (payload: LeadFormPrefill) => void
+) => {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  const handler = (event: Event) => {
+    const customEvent = event as CustomEvent<LeadFormPrefill>;
+    callback(customEvent.detail);
+  };
+
+  window.addEventListener(LEAD_FORM_EVENT, handler as EventListener);
+
+  return () => {
+    window.removeEventListener(LEAD_FORM_EVENT, handler as EventListener);
+  };
+};


### PR DESCRIPTION
## Summary
- add a schema-driven lead capture section powered by content-matrix.json and send submissions to a configurable automation endpoint
- wire hero, packages, and final call-to-action buttons to scroll/prefill the new form and reuse a shared founder call helper
- document required environment variables for the lead form and optional scheduling link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6bd5b7908321b94ab73f1387addb