### PR TITLE
Add router context and global navigation layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import AppRouter from './components/AppRouter';
 import SmoothBackground from './ui/SmoothBackground';
+import Navigation from './ui/Navigation';
 
 export default function App() {
   console.log('🚀 App component rendering - Smooth Background System');
@@ -8,7 +9,10 @@ export default function App() {
   return (
     <SmoothBackground className="min-h-screen relative overflow-hidden">
       {/* Smooth Background System */}
-      <AppRouter />
+      <Navigation />
+      <main className="pt-20">
+        <AppRouter />
+      </main>
     </SmoothBackground>
   );
 }

--- a/src/components/AppRouter.tsx
+++ b/src/components/AppRouter.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import FloatingNavigation from '../ui/FloatingNavigation';
 import Hero from '../sections/Hero';
 import Features from '../sections/Features';
@@ -9,127 +10,237 @@ import FinalCTA from '../ui/FinalCTA';
 import SEOHead from './SEOHead';
 import { BRAND_NAME } from '@/content/brand';
 
-const AppRouter: React.FC = () => {
-  const [currentSection, setCurrentSection] = useState(0);
+const sectionIds = ['hero', 'features', 'services', 'packages', 'lead-form', 'final-cta'] as const;
+const sectionRoutes = ['/', '/features', '/services', '/packages', '/lead-form', '/contact'] as const;
 
-  // Handle 404 redirects from GitHub Pages
-  useEffect(() => {
-    const redirectPath = sessionStorage.getItem('redirectPath');
-    if (redirectPath && redirectPath !== '/Wittwizz/') {
-      sessionStorage.removeItem('redirectPath');
-      // Handle hash navigation for SPA sections
-      if (redirectPath.includes('#')) {
-        const hash = redirectPath.split('#')[1];
-        const sectionMap: { [key: string]: number } = {
-          features: 1,
-          services: 2,
-          packages: 3,
-          lead_form: 4,
-          'lead-form': 4,
-          contact: 5
-        };
-        if (sectionMap[hash] !== undefined) {
-          setTimeout(() => scrollToSection(sectionMap[hash]), 100);
-        }
-      }
+const routeToSectionIndex: Record<string, number> = {
+  '/': 0,
+  '/features': 1,
+  '/services': 2,
+  '/packages': 3,
+  '/lead-form': 4,
+  '/lead_form': 4,
+  '/contact': 5
+};
+
+const hashToSectionIndex: Record<string, number> = {
+  hero: 0,
+  features: 1,
+  services: 2,
+  packages: 3,
+  'lead_form': 4,
+  'lead-form': 4,
+  contact: 5,
+  'final-cta': 5
+};
+
+const hashToRoute: Record<string, string> = {
+  hero: '/',
+  features: '/features',
+  services: '/services',
+  packages: '/packages',
+  'lead_form': '/lead-form',
+  'lead-form': '/lead-form',
+  contact: '/contact',
+  'final-cta': '/contact'
+};
+
+const LandingPage: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [currentSection, setCurrentSection] = React.useState(() => routeToSectionIndex[location.pathname] ?? 0);
+  const currentSectionRef = React.useRef(currentSection);
+
+  const scrollToSection = React.useCallback((sectionIndex: number) => {
+    const sectionId = sectionIds[sectionIndex];
+    if (!sectionId) {
+      return;
+    }
+
+    const targetSection = document.querySelector(`[data-section="${sectionId}"]`) as HTMLElement | null;
+    if (targetSection) {
+      const header = document.querySelector('[data-app-navigation]') as HTMLElement | null;
+      const headerOffset = (header?.offsetHeight ?? 0) + 16;
+      const targetPosition = targetSection.getBoundingClientRect().top + window.scrollY - headerOffset;
+
+      window.scrollTo({ top: Math.max(targetPosition, 0), behavior: 'smooth' });
     }
   }, []);
 
-  // Track which section is currently in view
-  useEffect(() => {
+  const handleSectionNavigate = React.useCallback(
+    (sectionIndex: number) => {
+      scrollToSection(sectionIndex);
+      const targetPath = sectionRoutes[sectionIndex];
+      if (targetPath && location.pathname !== targetPath) {
+        navigate(targetPath);
+      }
+    },
+    [navigate, location.pathname, scrollToSection]
+  );
+
+  React.useEffect(() => {
+    const handleSectionRequest: EventListener = (event) => {
+      const customEvent = event as CustomEvent<number>;
+      if (typeof customEvent.detail === 'number') {
+        scrollToSection(customEvent.detail);
+      }
+    };
+
+    window.addEventListener('app:navigate-section', handleSectionRequest);
+    return () => window.removeEventListener('app:navigate-section', handleSectionRequest);
+  }, [scrollToSection]);
+
+  React.useEffect(() => {
+    currentSectionRef.current = currentSection;
+  }, [currentSection]);
+
+  React.useEffect(() => {
+    const redirectPath = sessionStorage.getItem('redirectPath');
+    if (!redirectPath) {
+      return;
+    }
+
+    sessionStorage.removeItem('redirectPath');
+
+    const normalizedPath = redirectPath.replace('/Wittwizz', '') || '/';
+    const [rawPath, rawHash] = normalizedPath.split('#');
+
+    let cleanedPath = rawPath?.trim() || '/';
+    if (!cleanedPath.startsWith('/')) {
+      cleanedPath = `/${cleanedPath}`;
+    }
+    cleanedPath = cleanedPath.replace(/\/+$/, '') || '/';
+
+    if (rawHash) {
+      const hash = rawHash.toLowerCase();
+      const routeFromHash = hashToRoute[hash];
+
+      if (routeFromHash) {
+        if (routeFromHash !== location.pathname) {
+          navigate(routeFromHash, { replace: true });
+        } else {
+          const sectionIndex = hashToSectionIndex[hash];
+          if (sectionIndex !== undefined) {
+            scrollToSection(sectionIndex);
+          }
+        }
+        return;
+      }
+
+      const sectionIndex = hashToSectionIndex[hash];
+      if (sectionIndex !== undefined) {
+        scrollToSection(sectionIndex);
+        return;
+      }
+    }
+
+    if (cleanedPath !== location.pathname) {
+      navigate(cleanedPath, { replace: true });
+    }
+  }, [navigate, location.pathname, scrollToSection]);
+
+  const desiredSectionIndex = React.useMemo(() => {
+    if (location.hash) {
+      const hash = location.hash.replace('#', '').toLowerCase();
+      if (hashToSectionIndex[hash] !== undefined) {
+        return hashToSectionIndex[hash];
+      }
+    }
+
+    if (routeToSectionIndex[location.pathname] !== undefined) {
+      return routeToSectionIndex[location.pathname];
+    }
+
+    return 0;
+  }, [location.hash, location.pathname]);
+
+  React.useEffect(() => {
+    setCurrentSection((prev) => (prev === desiredSectionIndex ? prev : desiredSectionIndex));
+  }, [desiredSectionIndex]);
+
+  React.useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      scrollToSection(desiredSectionIndex);
+    }, 100);
+
+    return () => window.clearTimeout(timeout);
+  }, [desiredSectionIndex, scrollToSection]);
+
+  React.useEffect(() => {
     const handleScroll = () => {
       const scrollY = window.scrollY;
       const windowHeight = window.innerHeight;
-      
-      // Calculate which section is most visible
-      const sections = [
-        { id: 0, element: document.querySelector('[data-section="hero"]') },
-        { id: 1, element: document.querySelector('[data-section="features"]') },
-        { id: 2, element: document.querySelector('[data-section="services"]') },
-        { id: 3, element: document.querySelector('[data-section="packages"]') },
-        { id: 4, element: document.querySelector('[data-section="lead-form"]') },
-        { id: 5, element: document.querySelector('[data-section="final-cta"]') }
-      ];
+      let activeSection = currentSectionRef.current;
 
-      let activeSection = 0;
-      
-      sections.forEach((section, index) => {
-        if (section.element) {
-          const rect = section.element.getBoundingClientRect();
+      sectionIds.forEach((sectionId, index) => {
+        const element = document.querySelector(`[data-section="${sectionId}"]`);
+        if (element instanceof HTMLElement) {
+          const rect = element.getBoundingClientRect();
           const sectionTop = rect.top + scrollY;
           const sectionBottom = sectionTop + rect.height;
-          
-          // Check if this section is in the center of the viewport
+
           if (scrollY + windowHeight / 2 >= sectionTop && scrollY + windowHeight / 2 <= sectionBottom) {
             activeSection = index;
           }
         }
       });
-      
-      setCurrentSection(activeSection);
+
+      if (activeSection !== currentSectionRef.current) {
+        currentSectionRef.current = activeSection;
+        setCurrentSection(activeSection);
+      }
     };
 
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Function to scroll to a specific section
-  const scrollToSection = (sectionIndex: number) => {
-    const sections = ['hero', 'features', 'services', 'packages', 'lead-form', 'final-cta'];
-    
-    const targetSection = document.querySelector(`[data-section="${sections[sectionIndex]}"]`);
-    if (targetSection) {
-      targetSection.scrollIntoView({ behavior: 'smooth' });
-    }
-  };
-
-  // Get section-specific SEO data
-  const getSectionSEO = () => {
+  const sectionSEO = React.useMemo(() => {
     const sectionData = [
       {
         title: `${BRAND_NAME} - AI-Powered Brand & Growth Partner`,
         description: "AI-powered brand, web, and growth partner for India's startups. Founder-friendly, efficient delivery.",
-        canonical: "https://wittwizz.github.io/Wittwizz/"
+        canonical: 'https://wittwizz.github.io/Wittwizz/'
       },
       {
         title: `Features - ${BRAND_NAME}`,
-        description: "Lightning fast delivery, precision focused approach, and launch-ready solutions for startups.",
-        canonical: "https://wittwizz.github.io/Wittwizz/#features"
+        description: 'Lightning fast delivery, precision focused approach, and launch-ready solutions for startups.',
+        canonical: 'https://wittwizz.github.io/Wittwizz/#features'
       },
       {
         title: `Services - ${BRAND_NAME}`,
-        description: "Complete digital services: Brand development, web development, and growth marketing for startups.",
-        canonical: "https://wittwizz.github.io/Wittwizz/#services"
+        description: 'Complete digital services: Brand development, web development, and growth marketing for startups.',
+        canonical: 'https://wittwizz.github.io/Wittwizz/#services'
       },
       {
         title: `Packages & Pricing - ${BRAND_NAME}`,
-        description: "Affordable packages for startups: Essentials, Growth, and Scale packages with transparent pricing.",
-        canonical: "https://wittwizz.github.io/Wittwizz/#packages"
+        description: 'Affordable packages for startups: Essentials, Growth, and Scale packages with transparent pricing.',
+        canonical: 'https://wittwizz.github.io/Wittwizz/#packages'
       },
       {
         title: `Plan Your Sprint - ${BRAND_NAME}`,
         description: `Tell us about your goals and budget to receive a tailored ${BRAND_NAME} launch sprint plan.`,
-        canonical: "https://wittwizz.github.io/Wittwizz/#lead_form"
+        canonical: 'https://wittwizz.github.io/Wittwizz/#lead_form'
       },
       {
         title: `Contact Us - ${BRAND_NAME}`,
         description: `Get started with ${BRAND_NAME}. Schedule a call or start your project today.`,
-        canonical: "https://wittwizz.github.io/Wittwizz/#contact"
+        canonical: 'https://wittwizz.github.io/Wittwizz/#contact'
       }
     ];
+
     return sectionData[currentSection] || sectionData[0];
-  };
+  }, [currentSection]);
 
   return (
     <>
-      {/* Dynamic SEO Head */}
-      <SEOHead {...getSectionSEO()} />
-      
-      {/* Beautiful Floating Navigation - Synced with current section */}
-      <FloatingNavigation currentPage={currentSection} onNavigate={scrollToSection} />
-      
-      {/* Complete Page with Smooth Background Blending */}
-      <div className="pt-20">
+      <SEOHead {...sectionSEO} />
+
+      <FloatingNavigation currentPage={currentSection} onNavigate={handleSectionNavigate} />
+
+      <div>
         <div data-section="hero">
           <Hero />
         </div>
@@ -152,5 +263,18 @@ const AppRouter: React.FC = () => {
     </>
   );
 };
+
+const AppRouter: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<LandingPage />} />
+    <Route path="/features" element={<LandingPage />} />
+    <Route path="/services" element={<LandingPage />} />
+    <Route path="/packages" element={<LandingPage />} />
+    <Route path="/lead-form" element={<LandingPage />} />
+    <Route path="/lead_form" element={<LandingPage />} />
+    <Route path="/contact" element={<LandingPage />} />
+    <Route path="*" element={<Navigate to="/" replace />} />
+  </Routes>
+);
 
 export default AppRouter;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import './styles/tokens.css'
 import './styles/index.css'
@@ -15,6 +16,8 @@ initSEOPreloader();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )

--- a/src/ui/Navigation.tsx
+++ b/src/ui/Navigation.tsx
@@ -7,29 +7,33 @@ const Navigation: React.FC = () => {
   const location = useLocation();
 
   const navItems = [
-    { path: '/', label: 'Home', icon: '🏠' },
-    { path: '/features', label: 'Features', icon: '✨' },
-    { path: '/services', label: 'Services', icon: '🛠️' },
-    { path: '/packages', label: 'Packages', icon: '📦' }
+    { path: '/', label: 'Home', icon: '🏠', sectionIndex: 0 },
+    { path: '/features', label: 'Features', icon: '✨', sectionIndex: 1 },
+    { path: '/services', label: 'Services', icon: '🛠️', sectionIndex: 2 },
+    { path: '/packages', label: 'Packages', icon: '📦', sectionIndex: 3 }
   ];
 
-  const handleNavClick = (path: string) => {
+  const handleNavClick = (path: string, sectionIndex: number) => {
     // Close mobile menu if open
     setIsMenuOpen(false);
-    
-    // Add smooth scroll to top for new page
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+
+    if (location.pathname === path) {
+      window.dispatchEvent(new CustomEvent('app:navigate-section', { detail: sectionIndex }));
+    }
   };
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-40 bg-white/90 backdrop-blur-md border-b border-gray-200/50">
+    <nav
+      data-app-navigation
+      className="fixed top-0 left-0 right-0 z-40 bg-white/90 backdrop-blur-md border-b border-gray-200/50"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
-          <Link 
-            to="/" 
+          <Link
+            to="/"
             className="flex items-center space-x-2 text-2xl font-bold text-gray-900 hover:text-blue-600 transition-colors"
-            onClick={() => handleNavClick('/')}
+            onClick={() => handleNavClick('/', 0)}
           >
             <span className="text-3xl">🚀</span>
             <span>WittWizz</span>
@@ -41,7 +45,7 @@ const Navigation: React.FC = () => {
               <Link
                 key={item.path}
                 to={item.path}
-                onClick={() => handleNavClick(item.path)}
+                onClick={() => handleNavClick(item.path, item.sectionIndex)}
                 className={`flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
                   location.pathname === item.path
                     ? 'text-blue-600 bg-blue-50'
@@ -84,7 +88,7 @@ const Navigation: React.FC = () => {
                   <Link
                     key={item.path}
                     to={item.path}
-                    onClick={() => handleNavClick(item.path)}
+                    onClick={() => handleNavClick(item.path, item.sectionIndex)}
                     className={`flex items-center space-x-3 px-4 py-3 rounded-lg text-base font-medium transition-colors ${
                       location.pathname === item.path
                         ? 'text-blue-600 bg-blue-50'


### PR DESCRIPTION
## Summary
- wrap the root render in a `BrowserRouter` and display the shared `Navigation` header around the app content
- refactor `AppRouter` into routed landing content that keeps section-based scrolling, SEO metadata, and GitHub Pages redirects working
- sync navigation interactions with scrolling offsets so section jumps work under the fixed header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd781e397883218e152e6f91e7624d